### PR TITLE
Handle pending Arcade authorization interrupts

### DIFF
--- a/src/agent_arcade_tools/graph.py
+++ b/src/agent_arcade_tools/graph.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Dict, Sequence, Union, cast
 
 from arcadepy.types.shared.authorization_response import AuthorizationResponse
 from langchain_arcade import ToolManager
-from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import MemorySaver
@@ -224,7 +224,45 @@ def authorize(
     if not isinstance(state["messages"][-1], AIMessage):
         return {"messages": state["messages"]}
 
-    for tool_call in state["messages"][-1].tool_calls:
+    # Check if we've already interrupted for authorization
+    last_message = state["messages"][-1]
+    if hasattr(
+        last_message, "additional_kwargs"
+    ) and last_message.additional_kwargs.get("__auth_interrupted__"):
+        # After an interrupt, check if authorization is now complete
+        for tool_call in last_message.tool_calls:
+            tool_name = tool_call["name"]
+            if not tool_manager.requires_auth(tool_name):
+                continue
+            auth_status_response: AuthorizationResponse = tool_manager.wait_for_auth(
+                last_message.additional_kwargs["__auth_id__"]
+            )
+            if auth_status_response.status == "pending":
+                # If still not completed, return a tool message error
+                return {
+                    "messages": [
+                        ToolMessage(
+                            name=tool_name,
+                            content="Authorization is still pending. Please wait a moment and ask again.",
+                            tool_call_id=tool_call["id"],
+                        )
+                    ]
+                }
+            elif auth_status_response.status == "failed":
+                return {
+                    "messages": [
+                        ToolMessage(
+                            name=tool_name,
+                            content="Authorization failed. Please try again.",
+                            tool_call_id=tool_call["id"],
+                        )
+                    ]
+                }
+        # If we get here, all tools are now authorized
+        return {"messages": state["messages"]}
+
+    # Initial authorization check
+    for tool_call in last_message.tool_calls:
         tool_name = tool_call["name"]
         if not tool_manager.requires_auth(tool_name):
             continue
@@ -235,11 +273,17 @@ def authorize(
             # Immediately interrupt with the authorization URL
             if not auth_response.url:
                 raise ValueError("No authorization URL returned")
+
+            # Mark the message as having interrupted for auth and store the auth ID
+            last_message.additional_kwargs["__auth_interrupted__"] = True
+            last_message.additional_kwargs["__auth_id__"] = auth_response.id
+
             interrupt(
                 {
-                    "message": f"Visit the following URL to authorize: {auth_response.url}",
+                    "message": "Authorization is required. Click Authorize to sign in and give permission.",
                     "auth_url": auth_response.url,
                     "type": "authorization",
+                    "auth_id": auth_response.id,
                 }
             )
 

--- a/src/agent_arcade_tools/graph.py
+++ b/src/agent_arcade_tools/graph.py
@@ -315,6 +315,16 @@ def handle_tools(state: MessagesState) -> dict[str, Sequence[BaseMessage]]:
     return {"messages": [*state["messages"], *tool_response["messages"]]}
 
 
+def should_continue_after_authorization(state: MessagesState) -> str:
+    """Route authorization results to the next safe node."""
+    last_message = state["messages"][-1]
+    if isinstance(last_message, AIMessage):
+        return "tools"
+    if isinstance(last_message, ToolMessage):
+        return "agent"
+    return END
+
+
 # Build the workflow graph using StateGraph
 workflow = StateGraph(MessagesState, AgentConfigurable)
 
@@ -328,7 +338,9 @@ workflow.add_edge(START, "agent")
 workflow.add_conditional_edges(
     "agent", should_continue, ["authorization", "tools", END]
 )
-workflow.add_edge("authorization", "tools")
+workflow.add_conditional_edges(
+    "authorization", should_continue_after_authorization, ["agent", "tools", END]
+)
 workflow.add_edge("tools", "agent")
 
 # Set up memory for checkpointing the state

--- a/tests/integration_tests/test_graph.py
+++ b/tests/integration_tests/test_graph.py
@@ -339,9 +339,10 @@ def test_authorized_complete_flow() -> None:
                 found_interrupt = True
                 interrupt = chunk["__interrupt__"][0]
                 assert interrupt.value == {
-                    "message": "Visit the following URL to authorize: http://auth.test.url",
+                    "message": "Authorization is required. Click Authorize to sign in and give permission.",
                     "auth_url": "http://auth.test.url",
                     "type": "authorization",
+                    "auth_id": "test-auth-id",
                 }
                 assert interrupt.resumable is True
                 assert interrupt.when == "during"

--- a/tests/integration_tests/test_graph.py
+++ b/tests/integration_tests/test_graph.py
@@ -31,10 +31,12 @@ from langgraph.prebuilt import ToolNode
 from langgraph.types import interrupt
 
 from agent_arcade_tools.graph import (
+    authorize,
     call_agent,
     graph,
     handle_tools,
     should_continue,
+    should_continue_after_authorization,
     tool_manager,
 )
 
@@ -352,6 +354,61 @@ def test_authorized_complete_flow() -> None:
         assert auth_call_count == 1, (
             f"Expected exactly one auth call but got {auth_call_count}"
         )
+
+
+@pytest.mark.parametrize(
+    ("auth_status", "expected_content"),
+    [
+        (
+            "pending",
+            "Authorization is still pending. Please wait a moment and ask again.",
+        ),
+        ("failed", "Authorization failed. Please try again."),
+    ],
+)
+def test_resumed_pending_auth_routes_back_to_agent(
+    auth_status: str, expected_content: str
+) -> None:
+    """Test that incomplete resumed auth does not route into ToolNode."""
+    ai_message = AIMessage(
+        content="",
+        additional_kwargs={
+            "__auth_interrupted__": True,
+            "__auth_id__": "test-auth-id",
+        },
+        tool_calls=[
+            {
+                "name": "Google_ListEmails",
+                "args": {"n_emails": 5},
+                "id": "call_uh9TLO9zSlDbMppVD6w8YYU2",
+                "type": "tool_call",
+            }
+        ],
+    )
+    state = MessagesState(messages=[HumanMessage(content="check email"), ai_message])
+    config: RunnableConfig = {
+        "configurable": {
+            "user_id": "test-user",
+        }
+    }
+
+    with (
+        patch.object(tool_manager, "requires_auth", return_value=True),
+        patch.object(
+            tool_manager,
+            "wait_for_auth",
+            return_value=MockAuthResponse(status=auth_status),
+        ),
+    ):
+        result = authorize(state, config=config)
+
+    assert len(result["messages"]) == 1
+    auth_message = result["messages"][0]
+    assert isinstance(auth_message, ToolMessage)
+    assert auth_message.content == expected_content
+
+    next_state = MessagesState(messages=[*state["messages"], auth_message])
+    assert should_continue_after_authorization(next_state) == "agent"
 
 
 def test_email_check_flow() -> None:

--- a/tests/unit_tests/test_graph_structure.py
+++ b/tests/unit_tests/test_graph_structure.py
@@ -87,11 +87,11 @@ def test_graph_structure() -> None:
         ],
         edges=[
             Edge(source=START, target="agent"),
-            Edge(source="authorization", target="tools"),
             Edge(source="tools", target="agent"),
         ],
         conditional_edges={
             "agent": ["authorization", "tools", END],
+            "authorization": ["agent", "tools", END],
         },
     )
 
@@ -154,4 +154,13 @@ def test_graph_structure() -> None:
     expected_edges = set(expected_structure.conditional_edges["agent"])
     assert agent_edges == expected_edges, (
         f"Incorrect conditional edges from agent node. Expected {expected_edges}, got {agent_edges}"
+    )
+
+    authorization_edges = {"agent", "tools", END}
+    expected_authorization_edges = set(
+        expected_structure.conditional_edges["authorization"]
+    )
+    assert authorization_edges == expected_authorization_edges, (
+        "Incorrect conditional edges from authorization node. "
+        f"Expected {expected_authorization_edges}, got {authorization_edges}"
     )


### PR DESCRIPTION
## Summary
- handle pending Arcade authorization interrupts in the graph flow
- keep the previously verified local commit on a review branch instead of pushing directly to main

## Verification
- Passed previously: `uv run --extra dev pytest tests/integration_tests/test_graph.py::test_authorized_complete_flow tests/unit_tests`
- Passed previously: `uv run --extra dev ruff check src/agent_arcade_tools/graph.py tests/integration_tests/test_graph.py`
- Passed previously: `uv run --extra dev mypy --strict src/agent_arcade_tools/graph.py`

## Note
The full commit hook previously timed out in `tests/test_streamlit_app.py::test_stream_handling`, so this is opened as a PR for review instead of a direct main push.